### PR TITLE
Replace Firefox with Brave

### DIFF
--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -544,11 +544,11 @@ def run():
             cfg += cfgunfree
 
     cfg += cfgpkgs
-    # Use firefox as default as a graphical web browser, and add kate to plasma desktop
+    # Use Brave as default as a graphical web browser, and add kate to plasma desktop
     if gs.value("packagechooser_packagechooser") == "plasma":
-        catenate(variables, "pkgs", "\n    firefox\n    kate")
+        catenate(variables, "pkgs", "\n    brave\n    kate")
     elif gs.value("packagechooser_packagechooser") != "":
-        catenate(variables, "pkgs", "\n    firefox")
+        catenate(variables, "pkgs", "\n    brave")
     else:
         catenate(variables, "pkgs", "")
 

--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -546,7 +546,9 @@ def run():
     cfg += cfgpkgs
     # Use Brave as default as a graphical web browser, and add kate to plasma desktop
     if gs.value("packagechooser_packagechooser") == "plasma":
-        catenate(variables, "pkgs", "\n    brave\n    kate")
+        catenate(variables, "pkgs", "\n    brave\n    kate\n    discover\n    appstream-qt")
+    elif gs.value("packagechooser_packagechooser") == "gnome":
+        catenate(variables, "pkgs", "\n    brave\n    gnome-software\n    appstream")
     elif gs.value("packagechooser_packagechooser") != "":
         catenate(variables, "pkgs", "\n    brave")
     else:

--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -546,7 +546,7 @@ def run():
     cfg += cfgpkgs
     # Use Brave as default as a graphical web browser, and add kate to plasma desktop
     if gs.value("packagechooser_packagechooser") == "plasma":
-        catenate(variables, "pkgs", "\n    brave\n    kate\n    discover\n    appstream-qt")
+        catenate(variables, "pkgs", "\n    brave\n    kate\n    discover\n    appstream")
     elif gs.value("packagechooser_packagechooser") == "gnome":
         catenate(variables, "pkgs", "\n    brave\n    gnome-software\n    appstream")
     elif gs.value("packagechooser_packagechooser") != "":


### PR DESCRIPTION
There are a few key privacy-oriented features Brave has but Firefox doesn’t, chiefly among them being:
* [adblock-rust](https://github.com/brave/adblock-rust) — no need to install any add-ons to block ads; they’re blocked out of the box
* Tor integration

As mentioned by DistroTube a few times, Brave is a *much* better option than FF for this and a few other reasons. Makes a lot more sense, therefore, to consider it as a viable Firefox alternative.