### PR TITLE
Use the default efi mount point `/boot`

### DIFF
--- a/config/modules/partition.conf
+++ b/config/modules/partition.conf
@@ -4,7 +4,7 @@
 # This setting specifies the mount point of the EFI system partition. Some
 # distributions (Fedora, Debian, Manjaro, etc.) use /boot/efi, others (KaOS,
 # etc.) use just /boot.
-efiSystemPartition:     "/boot/efi"
+efiSystemPartition:     "/boot"
 
 # This optional setting specifies the size of the EFI system partition.
 # If nothing is specified, the default size of 300MiB will be used.

--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -39,7 +39,6 @@ cfghead = """# Edit this configuration file to define what should be installed o
 cfgbootefi = """  # Bootloader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
-  boot.loader.efi.efiSysMountPoint = "/boot/efi";
 
 """
 


### PR DESCRIPTION
Fixes #17 

- Changes default efi mount point to `/boot`
- Allow the [`boot.loader.efi.efiSysMountPoint`](https://search.nixos.org/options?channel=unstable&show=boot.loader.efi.efiSysMountPoint) to use it's default value