### PR TITLE
Do not use crypto_keyfile.bin in UEFI, but leave BIOS the same.

### DIFF
--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -54,6 +54,13 @@ cfgbootnone = """  # Disable bootloader.
 
 """
 
+cfgbootcrypt = """  # Setup keyfile
+  boot.initrd.secrets = {
+    "/crypto_keyfile.bin" = null;
+  };
+
+"""
+
 cfgbootgrubcrypt = """  # Enable grub cryptodisk
   boot.loader.grub.enableCryptodisk=true;
 
@@ -376,36 +383,30 @@ def run():
     else:
         cfg += cfgbootnone
 
-    # Don't use keyfile if no encrypted extra encrypted partitions
-    needkeyfile = False
-    for part in gs.value("partitions"):
-        if part["claimed"] == True and part["fsName"] == "luks" and part["device"] is not None and not part["mountPoint"] == "/":
-            needkeyfile = True
-            break
-
     # Check partitions
     for part in gs.value("partitions"):
         if part["claimed"] == True and part["fsName"] == "luks":
+            cfg += cfgbootcrypt
             if fw_type != "efi":
                 cfg += cfgbootgrubcrypt
             status = _("Setting up LUKS")
             libcalamares.job.setprogress(0.15)
-            if needkeyfile:
-                try:
-                    # Create /crypto_keyfile.bin
-                    libcalamares.utils.host_env_process_output(
-                        ["dd", "bs=512", "count=4", "if=/dev/random", "of="+root_mount_point+"/crypto_keyfile.bin", "iflag=fullblock"], None)
-                    libcalamares.utils.host_env_process_output(
-                        ["chmod", "600", root_mount_point+"/crypto_keyfile.bin"], None)
-                except subprocess.CalledProcessError:
-                    libcalamares.utils.error(
-                        "Failed to create /crypto_keyfile.bin")
-                    return (_("Failed to create /crypto_keyfile.bin"), _("Check if you have enough free space on your partition."))
+            try:
+                # Create /crypto_keyfile.bin
+                libcalamares.utils.host_env_process_output(
+                    ["dd", "bs=512", "count=4", "if=/dev/random", "of="+root_mount_point+"/crypto_keyfile.bin", "iflag=fullblock"], None)
+                libcalamares.utils.host_env_process_output(
+                    ["chmod", "600", root_mount_point+"/crypto_keyfile.bin"], None)
+            except subprocess.CalledProcessError:
+                libcalamares.utils.error(
+                    "Failed to create /crypto_keyfile.bin")
+                return (_("Failed to create /crypto_keyfile.bin"), _("Check if you have enough free space on your partition."))
             break
 
-    # Setup keys in /crypto_keyfile. Do not add rootfs
+    # Setup keys in /crypto_keyfile. If we use systemd-boot (EFI), don't add /
+    # Goal is to have one password prompt when booted
     for part in gs.value("partitions"):
-        if part["claimed"] == True and part["fsName"] == "luks" and part["device"] is not None and not part["mountPoint"] == "/":
+        if part["claimed"] == True and part["fsName"] == "luks" and part["device"] is not None and not (fw_type == "efi" and part["mountPoint"] == "/"):
             if part["fs"] == "linuxswap":
                 cfg += cfgswapcrypt
                 catenate(variables, "swapdev", part["luksMapperName"])


### PR DESCRIPTION
Fixes #24.

#21 broke encrypted swap by mishandling the removal of `crypto_keyfile.bin`. This reverts the original fix. Instead, we leave BIOS the same; that was secure as it was before. But we make sure to never enroll or even generate `crypto_keyfile.bin` when booting with UEFI. To ensure the user is only prompted once, we instead rely on initrd to reuse the passphras for every LUKS device.

NOTE: This is likely not a completely sufficient solution for users who choose manual partitioning. Mainly, if they create an unencrypted root partition with BIOS boot, it will still insecurely use `crypto_keyfile.bin` for other partitions that *are* encrypted. And if different passphrases are used for different partitions in UEFI, the user will be prompted multiple times at boot.

/cc @vlinkz @RaitoBezarius 