### PR TITLE
Make Firefox module ready to work with Gnome extension

### DIFF
--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -249,6 +249,7 @@ cfgmisc = """  # Enable CUPS to print documents.
   # services.xserver.libinput.enable = true;
 
 """
+
 cfgusers = """  # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.@@username@@ = {
     isNormalUser = true;
@@ -260,7 +261,13 @@ cfgusers = """  # Define a user account. Don't forget to set a password with ‘
 """
 
 cfgfirefox = """  # Install firefox.
-  programs.firefox.enable = true;
+  programs.firefox = {
+    enable = true;
+    package = pkgs.firefox;
+    nativeMessagingHosts.packages = with pkgs; [
+      browserpass
+    ];
+  };
 
 """
 
@@ -323,6 +330,7 @@ cfgtail = """  # Some programs need SUID wrappers, can be configured further or 
   system.stateVersion = "@@nixosversion@@"; # Did you read the comment?
 
 }
+
 """
 
 


### PR DESCRIPTION
As a newcomer installing the Gnome ISO, one would expect gnome extension to work right away with the "by default" installed firefox.

This PR comes after this discussion : https://github.com/NixOS/nixpkgs/issues/300577