### PR TITLE
Fix mount options to match schema change

### DIFF
--- a/config/modules/mount.conf
+++ b/config/modules/mount.conf
@@ -25,13 +25,13 @@ extraMounts:
       mountPoint: /sys
     - device: /dev
       mountPoint: /dev
-      options: bind
+      options: [ bind ]
     - device: tmpfs
       fs: tmpfs
       mountPoint: /run
     - device: /run/udev
       mountPoint: /run/udev
-      options: bind
+      options: [ bind ]
 
 extraMountsEfi:
     - device: efivarfs


### PR DESCRIPTION
In Calamares v3.3.6 (https://github.com/calamares/calamares/pull/1865), the options item requires an array, and string values are interpreted as characters separated by commas. This results in the string `bind` being passed as `mount -o b,i,n,d`.

This happened when I was installing from the GNOME ISO (`nixos-gnome-23.11.7202.e7cc61784ddf-x86_64-linux.iso`)

```
2024-05-20 - 18:24:09 [6]:     .. Running ("mount", "-o", "b,i,n,d", "/dev", "/tmp/calamares-root-vde541mx/dev") 
2024-05-20 - 18:24:09 [6]:     .. Target cmd: ("mount", "-o", "b,i,n,d", "/dev", "/tmp/calamares-root-vde541mx/dev") Exit code: 32 output:
 mount: /tmp/calamares-root-vde541mx/dev: /dev is not a block device.
       dmesg(1) may have more information after failed mount system call.
2024-05-20 - 18:24:09 [6]:     .. Running ("udevadm", "settle") 
2024-05-20 - 18:24:10 [6]:     .. Running ("sync") 
2024-05-20 - 18:24:10 [2]: WARNING: [PYTHON JOB]: "Cannot mount /dev" 
2024-05-20 - 18:24:10 [6]:     .. Running ("mount", "-t", "proc", "-o", "defaults", "proc", "/tmp/calamares-root-vde541mx/proc") 
2024-05-20 - 18:24:10 [6]:     .. Running ("udevadm", "settle") 
2024-05-20 - 18:24:10 [6]:     .. Running ("sync") 
2024-05-20 - 18:24:10 [6]:     .. Running ("mount", "-t", "tmpfs", "-o", "defaults", "tmpfs", "/tmp/calamares-root-vde541mx/run") 
2024-05-20 - 18:24:10 [6]:     .. Running ("udevadm", "settle") 
2024-05-20 - 18:24:10 [6]:     .. Running ("sync") 
2024-05-20 - 18:24:10 [6]:     .. Running ("mount", "-o", "b,i,n,d", "/run/udev", "/tmp/calamares-root-vde541mx/run/udev") 
2024-05-20 - 18:24:10 [6]:     .. Target cmd: ("mount", "-o", "b,i,n,d", "/run/udev", "/tmp/calamares-root-vde541mx/run/udev") Exit code: 32 output:
 mount: /tmp/calamares-root-vde541mx/run/udev: /run/udev is not a block device.
       dmesg(1) may have more information after failed mount system call.
```

Change the value to an array of strings to pass the correct mount options.