### PR TITLE
fix(mount): EFI umask

### DIFF
--- a/config/modules/mount.conf
+++ b/config/modules/mount.conf
@@ -5,16 +5,18 @@
 # target as a usable chroot / "live" system). Filesystems are
 # automatically mounted from the partitioning module. Filesystems
 # listed here are **extra**. The filesystems listed in *extraMounts*
-# are mounted in all target systems. The filesystems listed in
-# *extraMountsEfi* are mounted in the target system **only** if
-# the host machine uses UEFI.
+# are mounted in all target systems.
 ---
 # Extra filesystems to mount. The key's value is a list of entries; each
-# entry has four keys:
+# entry has five keys:
 #   - device    The device node to mount
-#   - fs        The filesystem type to use
+#   - fs (optional) The filesystem type to use
 #   - mountPoint Where to mount the filesystem
-#   - options (optional) Extra options to pass to mount(8)
+#   - options (optional) An array of options to pass to mount
+#   - efi (optional) A boolean that when true is only mounted for UEFI installs
+#
+# The device is not mounted if the mountPoint is unset or if the fs is
+# set to unformatted.
 #
 extraMounts:
     - device: proc
@@ -25,15 +27,36 @@ extraMounts:
       mountPoint: /sys
     - device: /dev
       mountPoint: /dev
-      options: bind
+      options: [ bind ]
     - device: tmpfs
       fs: tmpfs
       mountPoint: /run
     - device: /run/udev
       mountPoint: /run/udev
-      options: bind
-
-extraMountsEfi:
+      options: [ bind ]
     - device: efivarfs
       fs: efivarfs
       mountPoint: /sys/firmware/efi/efivars
+      efi: true
+
+# The mount options used to mount each filesystem.
+#
+# filesystem contains the name of the filesystem or on of three special
+# values, "default", efi" and "btrfs_swap".  The logic is applied in this manner:
+#   - If the partition is the EFI partition, the "efi" entry will be used
+#   - If the fs is btrfs and the subvolume is for the swapfile,
+#     the "btrfs_swap" entry is used
+#   - If the  filesystem is an exact match for filesystem, that entry is used
+#   - If no match is found in the above, the default entry is used
+#   - If there is no match and no default entry, "defaults" is used
+#   - If the mountOptions key is not present, "defaults" is used
+#
+# Each filesystem entry contains 3 keys, all of which are optional
+#   options - An array of mount options that is used on all disk types
+#   ssdOptions - An array of mount options combined with options for ssds
+#   hddOptions - An array of mount options combined with options for hdds
+# If combining these options results in an empty array, "defaults" is used
+#
+mountOptions:
+    - filesystem: efi
+      options: [ fmask=0077, dmask=0077 ]


### PR DESCRIPTION
This PR adds `mountOptions` for `efi` partitions to mount them with a narrower umask to fix #45 

This has not yet been tested, as I have 0 experience with calamares and no idea how I can test this.

resolves #45
closes #32 (changes included in this PR)
ref https://github.com/NixOS/nixpkgs/issues/279362