### PR TITLE
Don't emit autoLogin config with eval warning

### DIFF
--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -277,8 +277,8 @@ cfgfirefox = """  # Install firefox.
 """
 
 cfgautologin = """  # Enable automatic login for the user.
-  services.xserver.displayManager.autoLogin.enable = true;
-  services.xserver.displayManager.autoLogin.user = "@@username@@";
+  services.displayManager.autoLogin.enable = true;
+  services.displayManager.autoLogin.user = "@@username@@";
 
 """
 


### PR DESCRIPTION
Fix this evaluation warning on the first rebuild after install:

```
[test@nixos:~]$ sudo nixos-rebuild build
building Nix...
building the system configuration...
evaluation warning: The option `services.xserver.displayManager.autoLogin' defined in `/etc/nixos/configuration.nix' has been renamed to `services.displayManager.autoLogin'.
```