### PR TITLE
Respect Kernel setting in /etc/nixos-generate-config.conf

### DIFF
--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -8,6 +8,7 @@
 #   Calamares is Free Software: see the License-Identifier above.
 #
 
+import configparser
 import libcalamares
 import os
 import subprocess
@@ -336,6 +337,11 @@ cfgtail = """  # Some programs need SUID wrappers, can be configured further or 
 
 }
 """
+
+cfglatestkernel = """  # Use latest kernel.
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+"""
 def env_is_set(name):
     envValue = os.environ.get(name)
     return not (envValue is None or envValue == "")
@@ -387,6 +393,10 @@ def run():
     status = _("Configuring NixOS")
     libcalamares.job.setprogress(0.1)
 
+    ngc_cfg = configparser.ConfigParser()
+    ngc_cfg["Defaults"] = { "Kernel": "lts" }
+    ngc_cfg.read("/etc/nixos-generate-config.conf")
+
     # Create initial config file
     cfg = cfghead
     gs = libcalamares.globalstorage
@@ -412,6 +422,9 @@ def run():
         catenate(variables, "bootdev", bootdev)
     else:
         cfg += cfgbootnone
+
+    if ngc_cfg["Defaults"]["Kernel"] == "latest":
+        cfg += cfglatestkernel
 
     # Setup encrypted swap devices. nixos-generate-config doesn't seem to notice them.
     for part in gs.value("partitions"):

--- a/testing/nixos-generate-config.conf
+++ b/testing/nixos-generate-config.conf
@@ -1,0 +1,2 @@
+[Defaults]
+Kernel=latest

--- a/testing/test_baseline.py
+++ b/testing/test_baseline.py
@@ -17,6 +17,9 @@ BASELINE_CFG = """# Edit this configuration file to define what should be instal
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Use latest kernel.
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
   networking.hostName = "nixos"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
@@ -85,6 +88,7 @@ def test_baseline(
     mock_libcalamares,
     mock_getoutput,
     mock_check_output,
+    mock_open_ngcconf,
     mock_open_hwconf,
     mock_Popen,
 ):
@@ -98,6 +102,8 @@ def test_baseline(
 
     # libcalamares.job.setprogress(0.1)
     assert mock_libcalamares.job.setprogress.mock_calls[0] == mocker.call(0.1)
+
+    
 
     # libcalamares.job.setprogress(0.18)
     assert mock_libcalamares.job.setprogress.mock_calls[1] == mocker.call(0.18)
@@ -117,6 +123,10 @@ def test_baseline(
     assert mock_check_output.mock_calls[0] == mocker.call(
         ["pkexec", "nixos-generate-config", "--root", "/mnt/root"],
         stderr=subprocess.STDOUT,
+    )
+
+    mock_open_ngcconf.assert_called_once_with(
+        "/etc/nixos-generate-config.conf"
     )
 
     # hf = open(root_mount_point + "/etc/nixos/hardware-configuration.nix", "r")


### PR DESCRIPTION
Once this is merged, I can add the update to https://github.com/NixOS/nixpkgs/pull/355893 and that can finally be merged, allowing for booting a new kernel from the same ISO and maintaining that kernel in the installation.