### PR TITLE
Change default /boot partition size to 1GiB

### DIFF
--- a/config/modules/partition.conf
+++ b/config/modules/partition.conf
@@ -33,7 +33,7 @@
 # size. Distro's that allow more user latitude can set the minimum lower.
 efi:
     mountPoint:         "/boot"
-    recommendedSize:    512MiB
+    recommendedSize:    1GiB
     minimumSize:        32MiB
     label:              "EFI"
 
@@ -193,7 +193,7 @@ initialSwapChoice: none
 
 # Default filesystem type, used when a "new" partition is made.
 #
-# When replacing a partition, the new filesystem type will be from the 
+# When replacing a partition, the new filesystem type will be from the
 # defaultFileSystemType value. In other cases, e.g. Erase and Alongside,
 # as well as when using manual partitioning and creating a new
 # partition, this filesystem type is pre-selected. Note that


### PR DESCRIPTION
I have personally found that having a /boot partition of only 512MiB is just too small for NixOS. Even with automatic gc, when I have a 'change-my-system-setup session' one out of three `nixos-rebuild`s fails with an oom error, which is just annoying. Maybe for server setups 512MiB is fine, but I don't think those use the Calamares installer.
Of course one could manually partition, but that's always a pain, especially when there's encryption involved. So I think doubling the default size is reasonable.