### PR TITLE
Add COSMIC as an option on the Desktop section

### DIFF
--- a/config/modules/packagechooser.conf
+++ b/config/modules/packagechooser.conf
@@ -164,6 +164,14 @@ items:
                     Learn more at <a href=\"https://kde.org/plasma-desktop/\">kde.org/plasma-desktop</a></html>"
       screenshot: "/run/current-system/sw/share/calamares/images/plasma6.png"
 
+    - id: cosmic
+      packages: [ cosmic ]
+      name: COSMIC
+      description: "<html>COSMIC is a modern desktop environment developed by System76 for Pop!_OS and other Linux distributions. Built in Rust for enhanced performance, stability, and security, COSMIC features a custom theming system and streamlined auto-tiling workflow to maximize productivity.<br/>
+                    <br/>
+                    Learn more at <a href=\"https://system76.com/cosmic/\">system76.com/cosmic</a></html>"
+      screenshot: "/run/current-system/sw/share/calamares/images/cosmic.png"
+
     - id: xfce
       packages: [ xfce ]
       name: Xfce

--- a/modules/nixos/main.py
+++ b/modules/nixos/main.py
@@ -134,6 +134,12 @@ cfgplasma6 = """  # Enable the X11 windowing system.
 
 """
 
+cfgcosmic = """  # Enable the COSMIC Desktop Environment.
+  services.displayManager.cosmic-greeter.enable = true;
+  services.desktopManager.cosmic.enable = true;
+
+"""
+
 cfgxfce = """  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
@@ -581,6 +587,8 @@ def run():
         cfg += cfggnome
     elif gs.value("packagechooser_packagechooser") == "plasma6":
         cfg += cfgplasma6
+    elif gs.value("packagechooser_packagechooser") == "cosmic":
+        cfg += cfgcosmic
     elif gs.value("packagechooser_packagechooser") == "xfce":
         cfg += cfgxfce
     elif gs.value("packagechooser_packagechooser") == "pantheon":


### PR DESCRIPTION
A draft pull request for adding COSMIC as a Desktop environment option in the Graphical NixOS installer when COSMIC 1.0.0 releases

#### TODO:
  - [ ] Add a screenshot

cc: @NixOS/cosmic 