### PR TITLE
Remove deepin desktop option

### DIFF
--- a/config/modules/packagechooser.conf
+++ b/config/modules/packagechooser.conf
@@ -228,13 +228,14 @@ items:
                     Learn more at <a href=\"https://docs.buddiesofbudgie.org/\">buddiesofbudgie.org</a></html>"
       screenshot: "/run/current-system/sw/share/calamares/images/budgie.png"
 
-    - id: deepin
-      packages: [ deepin ]
-      name: Deepin
-      description: "<html>The Deepin Desktop Environment is an elegant, easy to use and reliable desktop environment.<br/>
-                    <br/>
-                    Learn more at <a href=\"https://www.deepin.org/\">deepin.org</a></html>"
-      screenshot: "/run/current-system/sw/share/calamares/images/deepin.png"
+    # deepin desktop environment is not yet stable enough, once it is, simply uncommenting the lines below is all that's needed to enable it as an option
+    # - id: deepin
+    #   packages: [ deepin ]
+    #   name: Deepin
+    #   description: "<html>The Deepin Desktop Environment is an elegant, easy to use and reliable desktop environment.<br/>
+    #                 <br/>
+    #                 Learn more at <a href=\"https://www.deepin.org/\">deepin.org</a></html>"
+    #   screenshot: "/run/current-system/sw/share/calamares/images/deepin.png"
 
     - id: ""
       packages: []


### PR DESCRIPTION
The deepin desktop environment has become unstable, especially after upgrading to qt6.9, It is not recommended to continue using it for the time being

Not fully tested, I think it should work, since Lumina is blocked in the same way